### PR TITLE
fix: update state with ldClient

### DIFF
--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -65,7 +65,8 @@ const ProviderWithState: FC<ProviderProps> = ({
 
         const mergedFlags = { ...state.flags, ...flattened }
         setState({
-          flags: mergedFlags
+          flags: mergedFlags,
+          ldClient
         })
       })
     }


### PR DESCRIPTION
I found out that ldClient was always `undefined` because we did not update the state after initializing it.