### PR TITLE
fix: update state with ldClient

### DIFF
--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -48,11 +48,13 @@ const ProviderWithState: FC<ProviderProps> = ({
   useEffect(() => {
     if (ldUser) {
       const ldClient = initLDClient(ldClientId, ldUser, flags)
-      if (!flags) {
-        ldClient.on("initialized", () => {
+      ldClient.on("initialized", () => {
+        if (!flags) {
           setState({ ldClient, flags: ldClient.allFlags() })
-        })
-      }
+        } else {
+          setState({ ldClient })
+        }
+      })
 
       ldClient.on("change", (changes: LDFlagChangeset) => {
         const flattened: LDFlagSet = {}
@@ -65,8 +67,7 @@ const ProviderWithState: FC<ProviderProps> = ({
 
         const mergedFlags = { ...state.flags, ...flattened }
         setState({
-          flags: mergedFlags,
-          ldClient
+          flags: mergedFlags
         })
       })
     }


### PR DESCRIPTION
We have different behaviors between flags and without. And now I update the state when the ldClient is initialized, I tested locally