### PR TITLE
fix: prevent the client from streaming

### DIFF
--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -54,11 +54,13 @@ const ProviderWithState: FC<ProviderProps> = ({
     }
   }, [ldClientId, ldUser.email])
 
+  const allFlags = ldClient ? ldClient.allFlags() : flags
+
   return (
     <Provider
       value={{
         ldClient,
-        flags: ldClient ? camelCaseKeys(ldClient.allFlags()) : flags
+        flags: camelCaseKeys(allFlags)
       }}
     >
       {children}


### PR DESCRIPTION
https://autoricardo.atlassian.net/browse/CAR-3560

By calling `on("change")`, we subscribe to real-time updates even though we're relying on them. Removing could save us some processing overhead and kill those weird long running open connections we discovered in APM

> The SDK does not subscribe to streaming real-time updates automatically when it is initialized. As a side effect, subscribing to the SDK's change event by calling .on('change') will cause the SDK to open a streaming connection to LaunchDarkly. This is the only way to receive realtime updates.

wdyt?