### PR TITLE
fix: check the whole user

### DIFF
--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -52,7 +52,7 @@ const ProviderWithState: FC<ProviderProps> = ({
         setLdClient(client)
       })
     }
-  }, [ldClientId, ldUser.email])
+  }, [ldClientId, ldUser])
 
   const allFlags = ldClient ? ldClient.allFlags() : flags
 


### PR DESCRIPTION
Since the user can be null, it is better to check the whole user object and not only the email, and we dont have always the email