### PR TITLE
[HOLD] chore: don't call allFlags

### DIFF
--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -52,18 +52,7 @@ const ProviderWithState: FC<ProviderProps> = ({
     }
   }, [ldClientId, ldUser?.key])
 
-  const allFlags = ldClient ? ldClient.allFlags() : flags
-
-  return (
-    <Provider
-      value={{
-        ldClient,
-        flags: camelCaseKeys(allFlags),
-      }}
-    >
-      {children}
-    </Provider>
-  )
+  return <Provider value={{ ldClient, flags }}>{children}</Provider>
 }
 
 export { Consumer, ProviderWithState as Provider }

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -52,7 +52,11 @@ const ProviderWithState: FC<ProviderProps> = ({
     }
   }, [ldClientId, ldUser?.key])
 
-  return <Provider value={{ ldClient, flags: camelCaseKeys(flags) }}>{children}</Provider>
+  return (
+    <Provider value={{ ldClient, flags: camelCaseKeys(flags) }}>
+      {children}
+    </Provider>
+  )
 }
 
 export { Consumer, ProviderWithState as Provider }

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -52,7 +52,7 @@ const ProviderWithState: FC<ProviderProps> = ({
     }
   }, [ldClientId, ldUser?.key])
 
-  return <Provider value={{ ldClient, flags }}>{children}</Provider>
+  return <Provider value={{ ldClient, flags: camelCaseKeys(flags) }}>{children}</Provider>
 }
 
 export { Consumer, ProviderWithState as Provider }


### PR DESCRIPTION
BREAKING CHANGE: does not initialize analytics client-side anymore

this is an experiment to attempt to reduce the MAU in launchdarkly