### PR TITLE
fix: failure to destruct user on urls that match the file extensions pattern

### DIFF
--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -69,11 +69,7 @@ const getLDRequestHandler = (sdkKey: string, getLDUser: GetLDUser) => {
       return next()
     }
 
-    if (
-      [/^\/_next/, /^\/static/, /^\/public/, /\.\w+$/].find((matcher) =>
-        url.match(matcher)
-      )
-    ) {
+    if ([/^\/_next/].find((matcher) => url.match(matcher))) {
       return next()
     }
 


### PR DESCRIPTION
https://app.datadoghq.com/logs?agg_m=count&agg_t=count&cols=core_host%2Ccore_service&from_ts=1596033751395&index=main&live=false&messageDisplay=inline&query=container_name%3A%2Acarforyou-listings-web%2A+kube_namespace%3Aproduction+%40res.statusCode%3A500&stream_sort=desc&to_ts=1596034571324

simplify the app route detection
- `static` is a convention of our app
- `public` does not actually appear in the path
- the last regex matched the url http://localhost:3000/fr/auto/audi/a3?typeKey=3.2

the last one caused 500eds in production for the given urls