### PR TITLE
Add guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ npm install @carforyou/ld
 
 Include the express middleware in your custom server to fetch flags server-side. Pass a function `getLDUser` in which you return the LD user object. For example, you could read the user id from an auth token and pass it as the key or generate uuids for public users.
 ```
-import { ldMiddleware }
+import { getLDRequestHandler } from "@carforyou/ld"
 
 const getLDUser = (req, res, isBot) => ({ key: "user@example.com", anonymous: false })
-const ldRequestHandler = ldMiddleware(LAUNCH_DARKLY_SDK_KEY, getLDUser)
+const ldRequestHandler = getLDRequestHandler(LAUNCH_DARKLY_SDK_KEY, getLDUser)
 
 const server = express()
-server.use(ldRequestHandler).listen()
+server.use(ldRequestHandler)
+      .use(nextHandler)
+      .listen()
 ```
 
 In `_app`, pass `req.ldData` to the LDProvider. Feature flags are statically available accross requests and page transitions.

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,5 +1,8 @@
 import getLDRequestHandler from "./requestHandler"
-export { getLDRequestHandler }
+
+export default {
+  getLDRequestHandler
+}
 
 // Additionally, export all components
 export * from "./index"

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,8 +1,6 @@
 import getLDRequestHandler from "./requestHandler"
 
-export default {
-  getLDRequestHandler
-}
+export { getLDRequestHandler }
 
 // Additionally, export all components
 export * from "./index"

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -75,15 +75,18 @@ const getLDRequestHandler = (sdkKey: string, getLDUser: GetLDUser) => {
 
     const isBot = matchesBotUserAgent(headers)
     const user = getLDUser({ req, res, isBot })
-    const ldClient = await getLDClient(app, sdkKey)
-    const allFlags = await ldClient.allFlagsState(user)
 
-    const ldData: LDData = {
-      user,
-      allFlags: allFlags.toJSON(),
-      isBot,
+    if (user) {
+      const ldClient = await getLDClient(app, sdkKey)
+      const allFlags = await ldClient.allFlagsState(user)
+
+      const ldData: LDData = {
+        user,
+        allFlags: allFlags.toJSON(),
+        isBot,
+      }
+      req.ldData = ldData
     }
-    req.ldData = ldData
 
     next()
   }

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -59,7 +59,7 @@ type GetLDUser = ({
 
 const getLDRequestHandler = (sdkKey: string, getLDUser: GetLDUser) => {
   return async (req, res, next) => {
-    const { app, url, headers } = req
+    const { app, pathname, headers } = req
 
     if (!sdkKey) {
       // eslint-disable-next-line no-console
@@ -69,7 +69,7 @@ const getLDRequestHandler = (sdkKey: string, getLDUser: GetLDUser) => {
       return next()
     }
 
-    if ([/^\/_next/].find((matcher) => url.match(matcher))) {
+    if ([/^\/_next/, /\.\w{1,4}$/].find((matcher) => pathname.match(matcher))) {
       return next()
     }
 


### PR DESCRIPTION
- don't process flags for requests with extensions (ie assets like robots.txt)
- don't process flags when there is no user (sane fallback behavior plus gives the `getLDUser` optional control)
