### PR TITLE
feat: pass ldData to routes in /next/_data

### DIFF
--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -79,7 +79,7 @@ const getLDRequestHandler = (
       return next()
     }
 
-    if (excludeRoutes(req.path)) {
+    if (excludeRoutes(path)) {
       return next()
     }
 

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -57,17 +57,14 @@ type GetLDUser = ({
   isBot: boolean
 }) => LDUser
 
-const defaultExcludeRoutes = (path: string): boolean => {
-  const nextPathMatch = path.match(/^\/_next/)
-  const assetMatch = path.match(/\.\w{1,4}$/)
-  return !!nextPathMatch && !!assetMatch
+export const isNotApplicationRoute = (path) => {
+  const isInNextPath = path.match(/^\/_next\/(?!data)/)
+  const isFileNotInNextDataPath = path.match(/^\/_next\/(?!data)/)
+
+  return !!isInNextPath && !!isFileNotInNextDataPath
 }
 
-const getLDRequestHandler = (
-  sdkKey: string,
-  getLDUser: GetLDUser,
-  excludeRoutes: (path: string) => boolean = defaultExcludeRoutes
-) => {
+const getLDRequestHandler = (sdkKey: string, getLDUser: GetLDUser) => {
   return async (req, res, next) => {
     const { app, path, headers } = req
 
@@ -79,7 +76,7 @@ const getLDRequestHandler = (
       return next()
     }
 
-    if (excludeRoutes(path)) {
+    if (isNotApplicationRoute(path)) {
       return next()
     }
 

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -57,7 +57,17 @@ type GetLDUser = ({
   isBot: boolean
 }) => LDUser
 
-const getLDRequestHandler = (sdkKey: string, getLDUser: GetLDUser) => {
+const defaultExcludeRoutes = (path: string): boolean => {
+  const nextPathMatch = path.match(/^\/_next/)
+  const assetMatch = path.match(/\.\w{1,4}$/)
+  return !!nextPathMatch && !!assetMatch
+}
+
+const getLDRequestHandler = (
+  sdkKey: string,
+  getLDUser: GetLDUser,
+  excludeRoutes: (path: string) => boolean = defaultExcludeRoutes
+) => {
   return async (req, res, next) => {
     const { app, path, headers } = req
 
@@ -69,7 +79,7 @@ const getLDRequestHandler = (sdkKey: string, getLDUser: GetLDUser) => {
       return next()
     }
 
-    if ([/^\/_next/, /\.\w{1,4}$/].find((matcher) => path.match(matcher))) {
+    if (excludeRoutes(req.path)) {
       return next()
     }
 


### PR DESCRIPTION
In order to tackle some bugs I need to be able to pass a custom function on the routes that shall be excluded by the middleware. The default behavior is kept as is for backwards compatibility.

Update: Behaves almost the same as before but does not exclude requests to /_next/data due to next fetching app data form getInitalPros and getServerside pros form _next/data/**/**/page.json