### PR TITLE
fix: use proper regex to exlude files from middlewares

### DIFF
--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -59,7 +59,7 @@ type GetLDUser = ({
 
 export const isNotApplicationRoute = (path) => {
   const isInNextPath = path.match(/^\/_next\/(?!data)/)
-  const isFileNotInNextDataPath = path.match(/^\/_next\/(?!data)/)
+  const isFileNotInNextDataPath = path.match(/(?<!\/_next\/data\/.*)\.\w{1,4}$/)
 
   return !!isInNextPath && !!isFileNotInNextDataPath
 }


### PR DESCRIPTION
Same as for https://github.com/carforyou/carforyou-ld-pkg/pull/new/fix-path-regext copied the same regex twice...