### PR TITLE
CAR-7939: do not log info and debug messages anymore

### DIFF
--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -4,7 +4,11 @@ import { Application, Request, Response } from "express"
 import { LDData, LDUser } from "./types"
 
 const createLDClient = async (sdkKey): Promise<LDClient> => {
-  const ldClient = LaunchDarkly.init(sdkKey)
+  const ldClient = LaunchDarkly.init(sdkKey, {
+    logger: LaunchDarkly.basicLogger({
+      level: "warn",
+    }),
+  })
   return ldClient.waitForInitialization()
 }
 


### PR DESCRIPTION
References: [CAR-7939](https://autoricardo.atlassian.net/browse/CAR-7939)

With SDK v6, launch darky introduced a [new logger](https://docs.launchdarkly.com/sdk/server-side/node-js/migration-5-to-6#understanding-changes-to-logging). As a result, info messages are newly logged to `console.error` filling up our monitoring tools with false positives.
Since the update, we can define the [levels](https://launchdarkly.github.io/node-server-sdk/index.html#ldloglevel) granularly.

Before:
![image](https://user-images.githubusercontent.com/71456764/124618807-64972180-de78-11eb-9068-ece3d53ee3e6.png)

After:
![image](https://user-images.githubusercontent.com/71456764/124619066-9b6d3780-de78-11eb-8292-bbfd3d7937ae.png)

How to test:
1. include prerelease in listings or DH
2. make sure LD is still working as expected
3. make sure there are no info logs on the console related to LD