### PR TITLE
CAR-8098: Integrate exhaustive-deps linting rule for pkgs in ld PKG

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,17 @@
 module.exports = {
-  extends: ["@carforyou/eslint-config/react"],
+  extends: ["@carforyou/eslint-config/react", "plugin:react-hooks/recommended"],
+  overrides: [
+    {
+      files: ["*"],
+      rules: {
+        "no-restricted-imports": "off",
+        "react-hooks/exhaustive-deps": [
+          "error",
+          {
+            additionalHooks: "useDeepCompareEffect",
+          },
+        ],
+      },
+    },
+  ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1024,7 +1024,6 @@
       "version": "7.13.17",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
       "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -2689,14 +2688,12 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "dev": true
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.3.tgz",
       "integrity": "sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2712,8 +2709,7 @@
     "@types/scheduler": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
-      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
-      "dev": true
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
     "@types/stack-utils": {
       "version": "2.0.0",
@@ -4691,8 +4687,7 @@
     "csstype": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
-      "dev": true
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4853,6 +4848,11 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
+    },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
     },
     "destroy": {
       "version": "1.0.4",
@@ -14747,8 +14747,7 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -16523,6 +16522,16 @@
       "requires": {
         "ip-regex": "^4.1.0",
         "tlds": "^1.203.0"
+      }
+    },
+    "use-deep-compare-effect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.6.1.tgz",
+      "integrity": "sha512-VB3b+7tFI81dHm8buGyrpxi8yBhzYZdyMX9iBJra7SMFMZ4ci4FJ1vFc1nvChiB1iLv4GfjqaYfvbNEpTT1rFQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": "^17.0.0",
+        "dequal": "^2.0.2"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "launchdarkly-js-client-sdk": "^2.16.0",
     "launchdarkly-node-server-sdk": "^6.0.0",
     "lodash.camelcase": "^4.3.0",
+    "use-deep-compare-effect": "^1.6.1",
     "uuidv4": "^6.2.0"
   },
   "devDependencies": {
@@ -40,6 +41,7 @@
     "@testing-library/react": "^12.0.0",
     "@types/jest": "^26.0.23",
     "@types/react": "^17.0.3",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "express": "^4.17.1",
     "jest": "^27.0.0",
     "react": "^17.0.0",

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, FC, ReactNode, useEffect, useMemo } from "react"
+import useDeepCompareEffect from "use-deep-compare-effect"
+import React, { createContext, FC, ReactNode, useMemo } from "react"
 import { initialize, LDClient, LDFlagSet } from "launchdarkly-js-client-sdk"
 
 import { LDData, LDUser } from "../types"
@@ -21,10 +22,10 @@ const LDContext = createContext<Context>(null)
 
 const LDProvider: FC<Props> = ({ initialLDData, clientId, children }) => {
   // persists the data initialized server-side on the client
-  const ldData = useMemo(() => initialLDData, [])
+  const ldData = useMemo(() => initialLDData, [initialLDData])
   const { user, isBot, initializeClient = true, allFlags = {} } = ldData || {}
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     // only enable client-side instrumentation for non-bots to prevent unnecessary MAU
     if (!isBot && initializeClient) {
       const client: LDClient = initialize(clientId, user)
@@ -33,7 +34,7 @@ const LDProvider: FC<Props> = ({ initialLDData, clientId, children }) => {
         client.allFlags()
       })
     }
-  }, [])
+  }, [clientId, initializeClient, isBot, user])
 
   const flags = camelCaseKeys(allFlags)
   return (


### PR DESCRIPTION
References [CAR-8098](https://autoricardo.atlassian.net/browse/CAR-8098)

## Motivation and context

We were working on the task to specify all missing useEffect dependencies. It is completed for listings and dealerhub. However, the rule is also important in our pkgs as well.


## Before

No linting rule and missing dependencies

## After

Linting rule and all dependencies are specified

## How to test

Browse through the apps where the `carforyou-ld-pkg` is used and make sure everything still works as expected.